### PR TITLE
incorrect fun get ast...

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,27 +1,52 @@
 import requests
 from bs4 import BeautifulSoup
 import re
-import solcast
-headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+import json
+from solc import compile_source
+
+headers = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+
 
 def remove_comment(text):
     pattern = r"/\*\*.*?\*/"
-    clean_text = re.sub(pattern, '', text, flags=re.DOTALL)
+    ctext = re.sub(pattern, '', text, flags=re.DOTALL)
 
     pattern = r"/\*.*?\*/"
-    clean_text = re.sub(pattern, '', clean_text, flags=re.DOTALL)
+    ctext = re.sub(pattern, '', ctext, flags=re.DOTALL)
 
     pattern = r"//.*?$"
-    clean_text = re.sub(pattern, '', clean_text, flags=re.MULTILINE)
+    clean_text = re.sub(pattern, '', ctext, flags=re.MULTILINE)
+
+    # clean_text = ctext.split('\n')
+    #
+    # while clean_text and clean_text[0].strip() == '':
+    #     clean_text.pop(0)
 
     return clean_text
-def get_code (url):
-    response = requests.get((url), headers=headers)
+
+
+def get_code(url):
+    response = requests.get(url, headers=headers)
     if response.ok:
         soup = BeautifulSoup(response.text, 'html.parser')
         pre_tags = soup.find('pre')
         for pre_tag in pre_tags:
             contract_code = pre_tag.get_text()
-        return print(remove_comment(contract_code))
+        return remove_comment(contract_code)
     else:
         raise ValueError(f"Failed to fetch contract source code from {url}")
+
+def get_ast(url):
+    compiled_code = compile_source(get_code(url))
+
+    # Извлекаем AST из выходных данных JSON
+    json_ast = json.loads(compiled_code)["contracts"]
+
+    # Доступ к AST для каждого контракта
+    for contract_name, contract_data in json_ast.items():
+        ast = contract_data["abi"]
+
+    return(ast)
+
+get_ast('https://etherscan.io/address/0x4B274807e2Cf091eAFCe26390f7FBeC626D4b0ab#code')


### PR DESCRIPTION
Необходимо преобразовать получаемый код с url в AST. Возникает перечень ошибок, скорее всего связанных с неверным типом вводимого кода в get_ast...

Traceback (most recent call last):
  File "K:\Proects\Python\ether-check\main.py", line 52, in <module>
    get_ast('https://etherscan.io/address/0x4B274807e2Cf091eAFCe26390f7FBeC626D4b0ab#code')
  File "K:\Proects\Python\ether-check\main.py", line 41, in get_ast
    compiled_code = compile_source(get_code(url))
  File "K:\Proects\Python\ether-check\venv\lib\site-packages\solc\main.py", line 108, in compile_source
    stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)
  File "K:\Proects\Python\ether-check\venv\lib\site-packages\solc\utils\string.py", line 85, in inner
    return force_obj_to_text(fn(*args, **kwargs))
  File "K:\Proects\Python\ether-check\venv\lib\site-packages\solc\wrapper.py", line 156, in solc_wrapper
    proc = subprocess.Popen(command,
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 1435, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] Не удается найти указанный файл
